### PR TITLE
Consumindo mais dados da API(EONET)

### DIFF
--- a/app/teste/page.tsx
+++ b/app/teste/page.tsx
@@ -2,10 +2,24 @@ export default async function Teste() {
   const response = await fetch('https://eonet.gsfc.nasa.gov/api/v2.1/events?source=InciWeb,EO')
   const data = await response.json()
   return (
-    <ul>
+    <div>
       {data.events.map((event) => (
-        <li key={event.id}>{event.title}</li>
+        <div>
+          <h3 key={event.id}>{event.title} - {event.id}</h3>
+          {event.sources.map((source) => (
+            <li key={source.id}>
+              <a href={source.url} target="blank">
+                {source.id}
+              </a>
+            </li>
+          ))}
+          {
+            event.geometries.map((geometrie) => (
+              <h3 key={geometrie.date}>{geometrie.coordinates}</h3>
+            ))
+          }
+        </div>
       ))}
-    </ul>
+    </div>
   )
 }


### PR DESCRIPTION
Fiz o arquivo consumir mais dados da api, porque antes só tava consumindo o nome dos eventos. Agora está consumindo dados como coordenadas e link para mais informações.